### PR TITLE
fix: add() is deprecated since symfony 7.4

### DIFF
--- a/report-converter.php
+++ b/report-converter.php
@@ -17,5 +17,5 @@ use Bartlett\Sarif\Console\Command\ConvertCommand;
  */
 
 $application = new Application();
-$application->add(new ConvertCommand());
+$application->addCommand(new ConvertCommand());
 $application->run();


### PR DESCRIPTION
addCommand() should be used on application. add() was remove with symfony console 8.0, which will be installed by default, if it isn't installed before (no version constraints)